### PR TITLE
CNAPP-23095: Add Last Seen Range selection to scan scope

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -30,6 +30,11 @@ apiCollections:
   collectionNames:
     - "collection-1"
     - "collection-2"    
+    
+runtimeWindow:
+  start: "1763031788" 
+  end: "1763031788"  
+  value: "30d"                 
 
 endpoints:
   - "endpoint-1"

--- a/internal/apievent/apievent.go
+++ b/internal/apievent/apievent.go
@@ -13,4 +13,5 @@ type ApiEvent struct {
 	Port          int         `json:"port,omitempty"`
 	Request       interface{} `json:"request,omitempty"`
 	Response      interface{} `json:"response,omitempty"`
+	LastSeenTime  int         `json:"last_seen_time,omitempty"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,13 @@ type Configuration struct {
 	ScanName       string         `json:"scanName"`
 	Endpoints      []string       `json:"endpoints,omitempty"`
 	APICollections APICollections `json:"apiCollections,omitempty"`
+	RuntimeWindow  RuntimeWindow  `json:"runtimeWindow,omitempty"`
+}
+
+type RuntimeWindow struct {
+	Start string `json:"start,omitempty"`
+	End   string `json:"end,omitempty"`
+	Value string `json:"value,omitempty"` // e.g., "5m", "5h" "5d"
 }
 
 func (c *Configuration) validate() error {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -56,8 +56,9 @@ func Run(ctx context.Context, configFilePath string) {
 	apiCollectionName := mgr.Cfg.APICollections.DbCollectionName
 	collectionNames := mgr.Cfg.APICollections.CollectionNames
 	endpoints := mgr.Cfg.Endpoints
+	scanRuntimeWindow := mgr.Cfg.RuntimeWindow
 
-	events, err := mgr.findApiOperationDocuments(eventCollectionName, apiCollectionName, clusterId, collectionNames, endpoints)
+	events, err := mgr.findApiOperationDocuments(eventCollectionName, apiCollectionName, clusterId, collectionNames, endpoints, scanRuntimeWindow)
 	if err != nil {
 		mgr.Logger.Errorf("failed to find documents: %v", err)
 		return

--- a/internal/core/discovery.go
+++ b/internal/core/discovery.go
@@ -110,6 +110,7 @@ func (m *Manager) findShadowAndZombieApis(events *hashset.Set, modelsMap map[str
 					StatusCode:    event.ResponseCode,
 					Port:          event.Port,
 					Type:          util.FindingTypeShadow,
+					LastSeenTime:  event.LastSeenTime,
 				})
 			}
 		}
@@ -137,6 +138,7 @@ func (m *Manager) findShadowAndZombieApis(events *hashset.Set, modelsMap map[str
 									StatusCode:    event.ResponseCode,
 									Port:          event.Port,
 									Type:          util.FindingTypeZombie,
+									LastSeenTime:  event.LastSeenTime,
 								})
 							}
 						}

--- a/internal/core/reporter.go
+++ b/internal/core/reporter.go
@@ -28,6 +28,7 @@ type API struct {
 	Response               interface{}   `json:"response,omitempty"`
 	AssociatedApiSpecFiles []ApiSpecFile `json:"associatedApiSpecFiles,omitempty"`
 	Type                   string        `json:"type,omitempty"`
+	LastSeenTime           int           `json:"lastSeenTime,omitempty"`
 }
 
 type apiReport struct {


### PR DESCRIPTION
Fetch API events based on last seen
1. Relative scan window  (5m, 5h, 5d)
2. Absolute scan window (from_time: to to_time)

Add last seen to all the categorized APIs


Relative scan window - on demand

Request:

```
curl --location 'https://cwpp.dev.accuknox.com/observabilityapi/v3/scans' \
--header 'Authorization: Bearer eyJO8S9hqg97UvqlgdNGxcLPJOX2OanhLpSS-Z9S35lqBUuh-Xb9JiwS_yR8RwYsf93ZeYR4bZd_WDZUH0p3pstzOkOHR3QYwpsM_Uak8Dhg78yiAyN7odThu4TzhTuLmBIKZXCR0VYRejZSC0Cp9fq66XLuLfDoa00g' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'name=test21' \
--data-urlencode 'description%20=test' \
--data-urlencode 'label=abhishekaws' \
--data-urlencode 'schedule_type=On-demand' \
--data-urlencode 'enabled=true' \
--data-urlencode 'file_ids=691571317fb8c3397aa71e22' \
--data-urlencode 'relative_scan_time=30d'
```

Response: 

```
{
    "message": "Scan created successfully"
}
```

Absolute scan window - on demand

Request: 

```
curl --location 'https://cwpp.dev.accuknox.com/observabilityapi/v3/scans' \
--header 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJ0b2tlbl90eXBlIjoic2xpZGluZyIsImV4cCI6MTc2MzA4MDc0NywianRpIjoiNmYyZTlkODcyZjk0NGM2iJGgFPUbSoGYO8S9hqg97UvqlgdNGxcLPJOX2OanhLpSS-Z9S35lqBUuh-Xb9JiwS_yR8RwYsf93ZeYR4bZd_WDZUH0p3pstzOkOHR3QYwpsM_Uak8Dhg78yiAyN7odThu4TzhTuLmBIKZXCR0VYRejZSC0Cp9fq66XLuLfDoa00g' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'name=test22' \
--data-urlencode 'description%20=test' \
--data-urlencode 'label=abhishekaws' \
--data-urlencode 'schedule_type=On-demand' \
--data-urlencode 'enabled=true' \
--data-urlencode 'file_ids=691571317fb8c3397aa71e22' \
--data-urlencode 'absolute_scan_start_time=1762599788' \
--data-urlencode 'absolute_scan_end_time=1763031788'
```

Response

```
{
    "message": "Scan created successfully"
}
```


Relative scan window - scheduled scan

Request

```
curl --location 'https://cwpp.dev.accuknox.com/observabilityapi/v3/scans' \
--header 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJ0b2tlbl90eXBlIjoic2xpZGluZyIsImV4cCI6MTc2MzA4MDc0NywianRpIjoiNmYyZTlkODcyZjk0NGM2YzlhYWQ1NzA4MDZjYWRlMzIiLCJyZWZyZXNoX2V4cCI6MTc2MzA4ODIyMCwidXNlcl9pZCI6NTYxLCJzdWIiOiI1NjEiLCJpYXQiOjE3NjMwMDE4MjAsInRlbmFudC1pZCI6MTEsInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJ0ZW1wbGF0ZV9jcmVhdGUiLCJ0ZW1wbGF0ZV9kZWxldGUiLCJzYm9tX3VwZGF0ZSIsInNib21fY3JlYXRlIiwic2JvbV92aWV3Iiwic2JvbV9kZWxldzqGzcRouzJXOAMiJGgFPUbSoGYO8S9hqg97UvqlgdNGxcLPJOX2OanhLpSS-Z9S35lqBUuh-Xb9JiwS_yR8RwYsf93ZeYR4bZd_WDZUH0p3pstzOkOHR3QYwpsM_Uak8Dhg78yiAyN7odThu4TzhTuLmBIKZXCR0VYRejZSC0Cp9fq66XLuLfDoa00g' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'name=scheduled-test' \
--data-urlencode 'description%20=test' \
--data-urlencode 'label=abhishekaws' \
--data-urlencode 'schedule_type=Scheduled' \
--data-urlencode 'enabled=true' \
--data-urlencode 'file_ids=691571317fb8c3397aa71e22' \
--data-urlencode 'relative_scan_time=30d' \
--data-urlencode 'frequency=Monthly' \
--data-urlencode 'schedule_days=Thu' \
--data-urlencode 'time=00:00'
```


Response

```
{
    "message": "Scan created successfully"
}
```